### PR TITLE
Update taginfo.json

### DIFF
--- a/taginfo.json
+++ b/taginfo.json
@@ -1,6 +1,6 @@
 {
     "data_format": 1,
-    "data_url": "https://raw.githubusercontent.com/zlant/parking-lanes/master/taginfo.json",
+    "data_url": "https://zlant.github.io/parking-lanes/taginfo.json",
     "project": {
         "name": "Parking lanes viewer",
         "description": "Parking lanes viewer from OpenStreetMap",


### PR DESCRIPTION
I assume the "data_url" is supposed to be the public URL for this file, right? So this would be better suited for the deployed version, than the github-version?

CC @goldfndr (https://github.com/zlant/parking-lanes/pull/20)