### PR TITLE
Improve error handling with 429 specific message

### DIFF
--- a/src/parking/data-url.ts
+++ b/src/parking/data-url.ts
@@ -4,6 +4,7 @@ import L from 'leaflet'
 import { overpassUrl, osmDevUrl } from '../utils/links'
 
 /**
+ * Get the API request URL (eg. Overpass Turbo query URL *./
  * @param {L.LatLngBounds} bounds
  * @param {boolean} editorMode
  * @param {boolean} useDevServer


### PR DESCRIPTION
<img width="864" alt="Screen Shot 2021-09-24 at 7 37 57 pm" src="https://user-images.githubusercontent.com/10473201/134653541-f6842f36-ff44-4600-a651-5d945078dfd8.png">


Displays a user friendly message when too many requests sent to Overpass Turbo.