### PR TITLE
Add tooltip + code comment to DateTime picker

### DIFF
--- a/src/parking/controls/datetime.ts
+++ b/src/parking/controls/datetime.ts
@@ -2,12 +2,16 @@ import L from 'leaflet'
 import { hyper } from 'hyperhtml/esm'
 import dayjs from 'dayjs'
 
+// The map can only show one condition.
+// If `parking:condition` tags are present,
+// changing the date/time will pick the fitting color getColorByDate().
 export default L.Control.extend({
     onAdd: (map: L.Map) => hyper`
         <input id="datetime-input"
                class="leaflet-control-layers control-padding control-bigfont"
                style="width: 150px"
                type="datetime-local"
+               title="If parking:condition present, show kind of parking at this time of day and day of week."
                onmousedown=${L.DomEvent.stopPropagation}
                ondblclick=${L.DomEvent.stopPropagation}
                onpointerdown=${L.DomEvent.stopPropagation}>`,


### PR DESCRIPTION
This adds some text to explain what the date time picker does. Also a code comment.
The tooltip is not very discoverable, but at least some info for those that hover over the field for longer.

See https://github.com/zlant/parking-lanes/issues/53 for details.

