### PR TITLE
Show background-layer picker in both modes

### DIFF
--- a/src/parking/interface.ts
+++ b/src/parking/interface.ts
@@ -115,6 +115,8 @@ export function initMap(): L.Map {
     map.on('click', closeLaneInfo)
     map.on('click', areaInfoControl.closeAreaInfo)
 
+    layersControl.addTo(map);
+
     // @ts-expect-error
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const hash = new L.Hash(map)
@@ -309,7 +311,6 @@ async function handleEditorModeCheckboxChange(e: Event | any) {
                 await authenticate(useDevServer)
             }
             editorMode = true
-            layersControl.addTo(map)
             editorModeLabel.style.color = 'green'
             resetLastBounds()
             handleMapMoveEnd()
@@ -319,8 +320,7 @@ async function handleEditorModeCheckboxChange(e: Event | any) {
         }
     } else {
         editorMode = false
-        // @ts-expect-error
-        layersControl.remove(map)
+
         if (map.hasLayer(tileLayers.esri)) {
             map.removeLayer(tileLayers.esri)
             map.addLayer(tileLayers.mapnik)


### PR DESCRIPTION
This shows the layer picker in both editor modes. The goal is, to allow users to browse map using areal images.

<img width="243" alt="edit mode" src="https://user-images.githubusercontent.com/111561/152222829-e983308b-02e8-4f0d-ae57-ef8e45f42776.png">
<img width="270" alt="view mode layer open" src="https://user-images.githubusercontent.com/111561/152222837-63f6e933-96b2-4365-94aa-84a9f5f80dff.png">
<img width="227" alt="view mode" src="https://user-images.githubusercontent.com/111561/152222841-18d0badb-404c-42b5-8c8d-330f121b5760.png">
