### PR TITLE
Add debug flag to gh-pages Deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "webpack serve",
     "build": "cross-env NODE_ENV='production' webpack",
     "analyze": "cross-env NODE_ENV='production' cross-env ANALYZE=true webpack",
-    "deploy": "gh-pages -d dist",
+    "deploy": "NODE_DEBUG=gh-pages gh-pages -d dist",
     "typecheck": "tsc --noEmit"
   },
   "keywords": [],


### PR DESCRIPTION
Add `NODE_DEBUG=gh-pages` debug info. It is not a lot more text in the console but helps understand what is going on.

Also, one needs to follow https://github.com/tschaub/gh-pages/issues/413 to setup the gh-pages deploy nowadays. Should I add this to the readme?