### PR TITLE
Ignore some roads for the editor

### DIFF
--- a/src/parking/controls/fetch.ts
+++ b/src/parking/controls/fetch.ts
@@ -1,44 +1,51 @@
+/* eslint-disable multiline-ternary */
 import L from 'leaflet'
 import { hyper } from 'hyperhtml/esm'
 import { OsmDataSource } from '../../utils/types/osm-data'
+import { editorMode } from '../interface'
 
 export default L.Control.extend({
-        <div id="fetch-control"
-             class="fetch-control"
-             tabindex="-1"
-             onblur="${handleBlur}"
-             onmousedown=${L.DomEvent.stopPropagation}
-             ondblclick=${L.DomEvent.stopPropagation}
-             onpointerdown=${L.DomEvent.stopPropagation}
-             onclick=${L.DomEvent.stopPropagation}>
-            <div class="leaflet-control-layers control-bigfont control-button">
-                <div class="fetch-control_wrapper">
-                    <div id="download-btn" class="fetch-control_button">
-                        Fetch parking data
-                    </div>
-                    <div class="fetch-control_toggle"
-                         onclick=${handleToggleClick} />
     onAdd: (_map: L.Map) => hyper`
+    <div id="fetch-control"
+         class="fetch-control"
+         tabindex="-1"
+         onblur="${handleBlur}"
+         onmousedown=${L.DomEvent.stopPropagation}
+         ondblclick=${L.DomEvent.stopPropagation}
+         onpointerdown=${L.DomEvent.stopPropagation}
+         onclick=${L.DomEvent.stopPropagation}>
+        <div class="leaflet-control-layers control-bigfont control-button">
+            <div class="fetch-control_wrapper">
+                <div id="download-btn" class="fetch-control_button">
+                    Fetch parking data
                 </div>
+                ${editorMode ? '' : hyper`
+                    <div class="fetch-control_toggle"
+                        onclick=${handleToggleClick}>
+                    </div>
+                `}
             </div>
+        </div>
+        ${editorMode ? '' : hyper`
             <div id="data-source-select" class="fetch-control_items">
-                <div data-value="${OsmDataSource.OverpassDe}" 
-                     class="fetch-control_item"
-                     onclick="${handleDataSourceChange}">
+                <div data-value="${OsmDataSource.OverpassDe}"
+                    class="fetch-control_item"
+                    onclick="${handleDataSourceChange}">
                     From overpass-turbo
                 </div>
                 <div data-value="${OsmDataSource.OsmOrg}"
-                     class="fetch-control_item"
-                     onclick="${handleDataSourceChange}">
+                    class="fetch-control_item"
+                    onclick="${handleDataSourceChange}">
                     From osm.org
                 </div>
                 <div data-value="${OsmDataSource.OverpassVk}"
-                     class="fetch-control_item"
-                     onclick="${handleDataSourceChange}">
+                    class="fetch-control_item"
+                    onclick="${handleDataSourceChange}">
                     From overpass-vk
                 </div>
             </div>
-        </div>`,
+        `}
+    </div>`,
 
     setFetchDataBtnClickListener(listener: (e?: MouseEvent) => any) {
         document.getElementById('download-btn')!.onclick = listener

--- a/src/parking/controls/fetch.ts
+++ b/src/parking/controls/fetch.ts
@@ -3,7 +3,6 @@ import { hyper } from 'hyperhtml/esm'
 import { OsmDataSource } from '../../utils/types/osm-data'
 
 export default L.Control.extend({
-    onAdd: (map: L.Map) => hyper`
         <div id="fetch-control"
              class="fetch-control"
              tabindex="-1"
@@ -19,6 +18,7 @@ export default L.Control.extend({
                     </div>
                     <div class="fetch-control_toggle"
                          onclick=${handleToggleClick} />
+    onAdd: (_map: L.Map) => hyper`
                 </div>
             </div>
             <div id="data-source-select" class="fetch-control_items">

--- a/src/parking/controls/github.ts
+++ b/src/parking/controls/github.ts
@@ -3,7 +3,7 @@ import { hyper } from 'hyperhtml/esm'
 import { handleJosmLinkClick } from '../../utils/josm'
 
 export default L.Control.extend({
-    onAdd: (map: L.Map) => hyper`
+    onAdd: (_map: L.Map) => hyper`
         <div class="leaflet-control-layers control-padding control-bigfont"
              onmouseenter=${showExternalEditorLinks}
              onmouseleave=${hideExternalEditorLinks}>

--- a/src/parking/data-url.ts
+++ b/src/parking/data-url.ts
@@ -22,7 +22,7 @@ function getOverpassEditorQuery(bounds: L.LatLngBounds) {
     return `
         [out:json];
         (
-            way[highway~"^motorway|trunk|primary|secondary|tertiary|unclassified|residential|service|living_street"][service!=parking_aisle][service!=driveway][access!=private](${convertBoundsToOverpassBbox(bounds)});
+            way[highway~"^motorway|trunk|primary|secondary|tertiary|unclassified|residential|service|living_street"][service!=emergency_access][service!=parking_aisle][service!=driveway][access!=private](${convertBoundsToOverpassBbox(bounds)});
         )->.a;
         (
             .a;

--- a/src/parking/data-url.ts
+++ b/src/parking/data-url.ts
@@ -22,7 +22,7 @@ function getOverpassEditorQuery(bounds: L.LatLngBounds) {
     return `
         [out:json];
         (
-            way[highway~"^motorway|trunk|primary|secondary|tertiary|unclassified|residential|service|living_street"][service!=parking_aisle](${convertBoundsToOverpassBbox(bounds)});
+            way[highway~"^motorway|trunk|primary|secondary|tertiary|unclassified|residential|service|living_street"][service!=parking_aisle][service!=driveway][access!=private](${convertBoundsToOverpassBbox(bounds)});
         )->.a;
         (
             .a;

--- a/src/parking/data-url.ts
+++ b/src/parking/data-url.ts
@@ -3,7 +3,7 @@ import { overpassDeUrl, overpassVkUrl, osmProdUrl, osmDevUrl } from '../utils/li
 import { OsmDataSource } from '../utils/types/osm-data'
 
 /**
- * Get the API request URL (eg. Overpass Turbo query URL *./
+ * Get the API request URL
  */
 export function getUrl(bounds: L.LatLngBounds, editorMode: boolean, useDevServer: boolean, source: OsmDataSource): string {
     if (editorMode || useDevServer || source === OsmDataSource.OsmOrg) {
@@ -16,20 +16,6 @@ export function getUrl(bounds: L.LatLngBounds, editorMode: boolean, useDevServer
         const overpassQuery = getOverpassViewerQuery(bounds).replace(/\s+/g, ' ')
         return overpassUrl + encodeURIComponent(overpassQuery)
     }
-}
-
-function getOverpassEditorQuery(bounds: L.LatLngBounds) {
-    return `
-        [out:json];
-        (
-            way[highway~"^motorway|trunk|primary|secondary|tertiary|unclassified|residential|service|living_street"][service!=emergency_access][service!=parking_aisle][service!=driveway][access!=private](${convertBoundsToOverpassBbox(bounds)});
-        )->.a;
-        (
-            .a;
-            .a >;
-            .a <;
-        );
-        out meta;`
 }
 
 function getOverpassViewerQuery(bounds: L.LatLngBounds) {

--- a/src/parking/interface.ts
+++ b/src/parking/interface.ts
@@ -41,7 +41,7 @@ import { parseParkingArea, updateAreaColorsByDate } from './parking-area'
 const editorName = 'PLanes'
 const version = '0.6.0'
 
-let editorMode = false
+export let editorMode = false
 const useDevServer = false
 let datetime = new Date()
 const viewMinZoom = 15
@@ -291,6 +291,16 @@ function getHighwaysOverpassQuery() {
 
 // Editor
 
+function setEditorMode(newEditorMode: boolean, map: L.Map) {
+    editorMode = newEditorMode
+
+    fetchControl.remove()
+    fetchControl.addTo(map)
+        .setFetchDataBtnClickListener(async() => await downloadParkingLanes(map))
+        .setDataSource(dataSource)
+        .setDataSourceChangeListener(handleDataSourceChange)
+}
+
 async function handleEditorModeCheckboxChange(e: Event | any) {
     const { map } = (window as OurWindow)
     if (e.currentTarget.checked) {
@@ -302,7 +312,7 @@ async function handleEditorModeCheckboxChange(e: Event | any) {
                 logout()
                 await authenticate(useDevServer)
             }
-            editorMode = true
+            setEditorMode(true, map)
             layersControl.addTo(map);
             (document.getElementById('ghc-editor-mode-label') as HTMLLabelElement).style.color = 'green'
             resetLastBounds()
@@ -312,7 +322,7 @@ async function handleEditorModeCheckboxChange(e: Event | any) {
             alert(err)
         }
     } else {
-        editorMode = false
+        setEditorMode(false, map)
         // @ts-expect-error
         layersControl.remove(map)
         if (map.hasLayer(tileLayers.esri)) {

--- a/src/utils/data-client.ts
+++ b/src/utils/data-client.ts
@@ -66,6 +66,15 @@ async function downloadContent(url: string): Promise<RawOsmData> {
     return resp.data
 }
 
+function includeOsmWay(tags) {
+    // Filter should never apply to non-highway ways
+    if (!tags?.highway) return true
+    const unwantedAccess = tags?.access === 'no' || tags?.access === 'private'
+    const unwantedService = ['emergency_access', 'parking_aisle', 'driveway'].includes(tags?.service)
+
+    return !(unwantedAccess || unwantedService)
+}
+
 function parseOsmResp(osmResp: RawOsmData): ParsedOsmData {
     const newData: ParsedOsmData = {
         ways: {},
@@ -80,7 +89,8 @@ function parseOsmResp(osmResp: RawOsmData): ParsedOsmData {
                 break
 
             case 'way':
-                newData.ways[el.id] = el
+                if (includeOsmWay(el.tags))
+                    newData.ways[el.id] = el
                 break
 
             case 'relation':


### PR DESCRIPTION
With this change, the following roads will be ignored when loading data for the editor:
- `service=emergency_access`
- `service=parking_aisle`
- `service=driveway`
- And also `access=private`

At least for Berlin, there should never be parking data needed for those roads, since they are implicitly no parking.

Is this the same where you are mapping? If not, I would change this PR to move those configuration in a local settings file per country.

--- 

## Update: Converted to draft

I am not sure anymore this change actually does what I want it to do. I would still love to year your feedback on the general idea (and maybe config), but will update here once I know that this is working.

## Update 2: The codes  does what I want it to do now.

The question is, though, if this is nice enough to be used.

- A new feature in this branch is https://github.com/zlant/parking-lanes/pull/66/commits/c35e826957cec60c6fe0aef9ffe4741623fec3a6 => What would be a clean way to re-render the dropdown? Or how could this code be refactored to fit into the style of the app? – Or should I remove it again?

- https://github.com/zlant/parking-lanes/pull/66/commits/3e273e65f9b2f5329701799ac0308290cb44116b filters the roads described above. => Is this approach OK?

- Also, I would love to learn how the data fetching actually works with the osm.org API. Where does the script specify the condition of which data is included? (Like the overpass query did.)