### PR TITLE
Add 'no' and 'separate' to legend interface and allow subline in legend

### DIFF
--- a/src/parking/controls/legend.ts
+++ b/src/parking/controls/legend.ts
@@ -3,12 +3,13 @@ import { hyper } from 'hyperhtml/esm'
 import { legend } from '../legend'
 
 export default L.Control.extend({
-    onAdd: (map: L.Map) => hyper`
+    onAdd: (_map: L.Map) => hyper`
         <div id="legend"
              class="leaflet-control-layers control-padding control-bigfont"
              onmouseenter=${handleLegendMouseEnter}
              onmouseleave=${handleLegendMouseLeave}
-             onclick=${changeLegendPinning}>
+             onclick=${changeLegendPinning}
+             style="max-width: 260px;">
             Legend
         </div>`,
 })
@@ -39,10 +40,10 @@ function handleLegendMouseLeave(e: Event) {
 function setLegendBody(el: Element) {
     el.innerHTML = legend
         .map(x => `<div class='legend-element' style='background-color:${x.color};'></div>
-            ${x.text}
-            ${x.subline ? `<br /><span class='legend-subline'>${x.subline}</span>` : ''}
+            <span title="parking:condition:<Side>=${x.condition}">${x.text}</span>
+            ${x.subline ? `<div class='legend-subline'>${x.subline}</div>` : '<br />'}
             `)
-        .join('<br />')
+        .join('\n')
 }
 
 function setLegendHead(el: Element) {

--- a/src/parking/controls/legend.ts
+++ b/src/parking/controls/legend.ts
@@ -38,7 +38,10 @@ function handleLegendMouseLeave(e: Event) {
 
 function setLegendBody(el: Element) {
     el.innerHTML = legend
-        .map(x => "<div class='legend-element' style='background-color:" + x.color + ";'></div> " + x.text)
+        .map(x => `<div class='legend-element' style='background-color:${x.color};'></div>
+            ${x.text}
+            ${x.subline ? `<br /><span class='legend-subline'>${x.subline}</span>` : ''}
+            `)
         .join('<br />')
 }
 

--- a/src/parking/controls/legend.ts
+++ b/src/parking/controls/legend.ts
@@ -3,13 +3,12 @@ import { hyper } from 'hyperhtml/esm'
 import { legend } from '../legend'
 
 export default L.Control.extend({
-    onAdd: (_map: L.Map) => hyper`
+    onAdd: () => hyper`
         <div id="legend"
              class="leaflet-control-layers control-padding control-bigfont"
              onmouseenter=${handleLegendMouseEnter}
              onmouseleave=${handleLegendMouseLeave}
-             onclick=${changeLegendPinning}
-             style="max-width: 260px;">
+             onclick=${changeLegendPinning}>
             Legend
         </div>`,
 })
@@ -41,9 +40,8 @@ function setLegendBody(el: Element) {
     el.innerHTML = legend
         .map(x => `<div class='legend-element' style='background-color:${x.color};'></div>
             <span title="parking:condition:<Side>=${x.condition}">${x.text}</span>
-            ${x.subline ? `<div class='legend-subline'>${x.subline}</div>` : '<br />'}
             `)
-        .join('\n')
+        .join('<br />')
 }
 
 function setLegendHead(el: Element) {

--- a/src/parking/legend.ts
+++ b/src/parking/legend.ts
@@ -2,7 +2,7 @@ import { ConditionColorDefinition } from '../utils/types/conditions'
 
 export const legend: ConditionColorDefinition[] = [
     /* eslint-disable no-multi-spaces */
-    { condition: 'free',         color: 'limegreen',    text: 'Free parking', subline: 'Also the fallback color if parking was mapped without conditions.' },
+    { condition: 'free',         color: 'limegreen',    text: 'Free parking' },
     { condition: 'disc',         color: 'yellowgreen',  text: 'Disc' },
     { condition: 'no_parking',   color: 'orange',       text: 'No parking' },
     { condition: 'no_stopping',  color: 'salmon',       text: 'No stopping' },

--- a/src/parking/legend.ts
+++ b/src/parking/legend.ts
@@ -5,10 +5,12 @@ export const legend: ConditionColorDefinition[] = [
     { condition: 'disc',         color: 'yellowgreen',  text: 'Disc' },
     { condition: 'no_parking',   color: 'orange',       text: 'No parking' },
     { condition: 'no_stopping',  color: 'salmon',       text: 'No stopping' },
+    { condition: 'no',           color: 'salmon',       text: 'No parking/stopping', subline: 'Mid section of dual lanes or just not applicable.' },
     { condition: 'free',         color: 'limegreen',    text: 'Free parking' },
     { condition: 'ticket',       color: 'dodgerblue',   text: 'Paid parking' },
     { condition: 'customers',    color: 'greenyellow',  text: 'For customers' },
     { condition: 'residents',    color: 'hotpink',      text: 'For residents' },
     { condition: 'disabled',     color: 'turquoise',    text: 'Disabled' },
+    { condition: 'separate',     color: 'gray',         text: 'Parking street site mapped separately' },
     /* eslint-enable no-multi-spaces */
 ]

--- a/src/parking/legend.ts
+++ b/src/parking/legend.ts
@@ -11,6 +11,6 @@ export const legend: ConditionColorDefinition[] = [
     { condition: 'customers',    color: 'greenyellow',  text: 'For customers' },
     { condition: 'residents',    color: 'hotpink',      text: 'For residents' },
     { condition: 'disabled',     color: 'turquoise',    text: 'Disabled' },
-    { condition: 'separate',     color: 'gray',         text: 'Parking street site mapped separately' },
+    { condition: 'separate',     color: 'gray',         text: 'Parking mapped separately' },
     /* eslint-enable no-multi-spaces */
 ]

--- a/src/parking/legend.ts
+++ b/src/parking/legend.ts
@@ -2,11 +2,11 @@ import { ConditionColorDefinition } from '../utils/types/conditions'
 
 export const legend: ConditionColorDefinition[] = [
     /* eslint-disable no-multi-spaces */
+    { condition: 'free',         color: 'limegreen',    text: 'Free parking', subline: 'Also the fallback color if parking was mapped without conditions.' },
     { condition: 'disc',         color: 'yellowgreen',  text: 'Disc' },
     { condition: 'no_parking',   color: 'orange',       text: 'No parking' },
     { condition: 'no_stopping',  color: 'salmon',       text: 'No stopping' },
-    { condition: 'no',           color: 'salmon',       text: 'No parking/stopping', subline: 'Mid section of dual lanes or just not applicable.' },
-    { condition: 'free',         color: 'limegreen',    text: 'Free parking' },
+    { condition: 'no',           color: '#FFC7B6',       text: 'Not applicable' },
     { condition: 'ticket',       color: 'dodgerblue',   text: 'Paid parking' },
     { condition: 'customers',    color: 'greenyellow',  text: 'For customers' },
     { condition: 'residents',    color: 'hotpink',      text: 'For residents' },

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -18,6 +18,11 @@ html, body, #map {
     overflow: hidden;
 }
 
+.legend-subline {
+    margin-left: 32px;
+    color: rgb(170, 170, 170);
+}
+
 .control-padding {
     padding: 4px 7px;
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -18,11 +18,6 @@ html, body, #map {
     overflow: hidden;
 }
 
-.legend-subline {
-    margin-left: 32px;
-    color: rgb(170, 170, 170);
-}
-
 .control-padding {
     padding: 4px 7px;
 }

--- a/src/utils/types/conditions.ts
+++ b/src/utils/types/conditions.ts
@@ -19,5 +19,4 @@ export interface ConditionColorDefinition {
     color: ConditionColor
     /** Text describing the condition */
     text: string
-    subline?: string
 }

--- a/src/utils/types/conditions.ts
+++ b/src/utils/types/conditions.ts
@@ -10,8 +10,7 @@ export interface ConditionInterface {
     condition: string | null
 }
 
-export type ConditionName = 'disc' | 'no_parking' | 'no_stopping' | 'free' | 'ticket'
-|'customers' | 'residents' | 'disabled' | 'disc'
+export type ConditionName = 'disc' | 'no_parking' | 'no_stopping' | 'free' | 'ticket' |'customers' | 'residents' | 'disabled' | 'disc' | 'no' | 'separate'
 
 export type ConditionColor = string
 
@@ -20,4 +19,5 @@ export interface ConditionColorDefinition {
     color: ConditionColor
     /** Text describing the condition */
     text: string
+    subline?: string
 }


### PR DESCRIPTION
1. Add `condition: no` which we use in Berlin to map places where the parking:lane schema does not apply "by design" and no more specific tagging is not correct. Mainly when mapped with `dual_carriageway=yes` ([Example](https://www.openstreetmap.org/way/764644563)), where one side is never to be parked on.

---

2. Add `condition: separate` to give this option visibility on the legend. However (TBD), this now collides a bit with the new (and very good!) rendering of of amenity=parking. I this it's still better having it this way. What are your thoughts?

---

3. This extend the legend to include an optional `subline` to explain the entry a bit more. ATM, its only used for one condition.

---

![image](https://user-images.githubusercontent.com/111561/152238474-68eff28c-96fa-4aba-ab68-938b88068f74.png)
