### PR TITLE
Improve max zoom

### DIFF
--- a/src/parking/interface.ts
+++ b/src/parking/interface.ts
@@ -51,6 +51,7 @@ const laneInfoControl = new LaneInfoControl({ position: 'topright' })
 const areaInfoControl = new AreaInfoControl({ position: 'topright' })
 const fetchControl = new FetchControl({ position: 'topright' })
 
+// Reminder: Check `maxMaxZoomFromTileLayers` in `generateStyleMapByZoom()`
 const tileLayers = {
     mapnik: L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',

--- a/src/parking/interface.ts
+++ b/src/parking/interface.ts
@@ -54,18 +54,19 @@ const fetchControl = new FetchControl({ position: 'topright' })
 const tileLayers = {
     mapnik: L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
-        maxZoom: 18,
+        maxZoom: 21,
+        maxNativeZoom: 19,
         className: 'mapnik_gray',
     }),
     esri: L.tileLayer('https://clarity.maptiles.arcgis.com/arcgis/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}', {
         attribution: "<a href='https://wiki.openstreetmap.org/wiki/Esri'>Terms & Feedback</a>",
-        maxZoom: 19,
+        maxZoom: 21,
         maxNativeZoom: 19,
     }),
     maxar: L.tileLayer('https://services.digitalglobe.com/earthservice/tmsaccess/tms/1.0.0/DigitalGlobe:ImageryTileService@EPSG:3857@jpg/{z}/{x}/{-y}.jpg?connectId=fa014fbc-6cbe-4b6f-b0ca-fbfb8d1e5b7d', {
         attribution: "<a href='https://wiki.openstreetmap.org/wiki/DigitalGlobe'>Terms & Feedback</a>",
-        maxZoom: 22,
-        maxNativeZoom: 22,
+        maxZoom: 21,
+        maxNativeZoom: 20,
     }),
 }
 

--- a/src/parking/lane-styles.ts
+++ b/src/parking/lane-styles.ts
@@ -3,7 +3,10 @@ import { StyleMapInterface } from '../utils/types/parking'
 function generateStyleMapByZoom(): { [key: number]: StyleMapInterface } {
     const map: { [key: number]: StyleMapInterface } = {}
 
-    for (const zoom of [...Array(20).keys()]) {
+    // Needs to be kept in sync with the max maxZoom from interface.js tileLayers.
+    const maxMaxZoomFromTileLayers = 22 + 1
+
+    for (const zoom of [...Array(maxMaxZoomFromTileLayers).keys()]) {
         map[zoom] = {}
         if (zoom <= 12) {
             map[zoom].offsetMajor = 1
@@ -30,7 +33,7 @@ function generateStyleMapByZoom(): { [key: number]: StyleMapInterface } {
             map[zoom].weightMajor = 3
             map[zoom].offsetMinor = 3
             map[zoom].weightMinor = 1.5
-        } else if (zoom >= 18) {
+        } else {
             map[zoom].offsetMajor = 8
             map[zoom].weightMajor = 3
             map[zoom].offsetMinor = 3


### PR DESCRIPTION
This has multiple parts:

1. It syncs the `maxZoom`, `maxNativeZoom` in order to make it easier to switch layer
2. It fixes the `maxZoom` for Maxar, which does not load data on https://zlant.github.io/parking-lanes/#21/52.50753/13.46417
3. It adds a reminder to keep the `maxZoom` in Sync with `generateStyleMapByZoom()` which caused an error in my build. I don't know why the error does not show in your build (maybe different NodeJS versions?), but in any case this should help with documenting the setup regardless.