### PR TITLE
Create .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*]
+charset = utf-8
+
+# 4 space indentation
+[*]
+indent_style = space
+indent_size = 4
+
+# Matches the exact files either package.json or .travis.yml
+[{package.json,.travis.yml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
This makes sure code formatter follow existing formatting styles.

I had to turn of most of my auto formatting for this project and with this I can turn on a bit again.

More at https://editorconfig.org/.
For VSCode use https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig.

---

While being on this topic, what are your thoughts on adding [Prettier](https://prettier.io/)? 