### PR TITLE
Add `separate` to list of `laneValues`

### DIFF
--- a/src/parking/controls/editor/editor-form.ts
+++ b/src/parking/controls/editor/editor-form.ts
@@ -300,6 +300,7 @@ const laneValues = [
     'marked',
     'fire_lane',
     'no',
+    'separate',
 ]
 
 const typeValues = [


### PR DESCRIPTION
This allows to choose the value from the list whenever the parking lanes where previously mapped separately.

Closes https://github.com/zlant/parking-lanes/issues/32.