### PR TITLE
Add VS Code config defaults for formatting with eslint

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+// Extension recommendations for VS Code
+// See also docs: https://code.visualstudio.com/updates/v1_6#_workspace-extension-recommendations
+{
+    "recommendations": ["dbaeumer.vscode-eslint"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+// https://www.roboleary.net/vscode/2020/09/17/vscode-workspace-settings.html
+// All settings https://code.visualstudio.com/docs/getstarted/settings#_default-settings
+{
+    "editor.formatOnSave": true,
+    "[typescript]": {
+        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    },
+    "[javascript]": {
+        "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+    }
+}


### PR DESCRIPTION
We chatted about prettier vs. eslint for formatting the code. This PR should help all that have prettier setup as default formatter to clarify that this repo does not use it but is formatted by eslint.

It might be, however, that this is specific to vs code configurations where prettier was set up to format everything; this maybe this is something to cherry pick for those who really need it?