### PR TITLE
Add host to changeset tags

### DIFF
--- a/src/utils/osm-client.ts
+++ b/src/utils/osm-client.ts
@@ -95,6 +95,7 @@ function createChangeset(editorName: string, editorVersion: string): Promise<str
                 tag: [
                     { $k: 'created_by', $v: `${editorName} ${editorVersion}` },
                     { $k: 'comment', $v: 'Parking lanes' },
+                    { $k: 'host', $v: `${window.location.origin}${window.location.pathname}` },
                 ],
             },
         },


### PR DESCRIPTION
This provides a link back to the editor which in turn helps readers of the changeset understand what tagging is applied and how.

The host value follows the example of iD (example https://www.openstreetmap.org/changeset/113127802). MapComplete also uses the host key but only the domain as value (example https://www.openstreetmap.org/changeset/113127802).