### PR TITLE
Add lint and lint:fix to package.json scripts, and pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run typecheck && npm run lint --fix

--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ Viewer:
 Editor:
 
 <img src="https://i.imgur.com/e0vsqUQ.png" alt="Editor UI">
+
+## Install git hook
+
+Run `npm run prepare`. This will install [Husky](https://github.com/typicode/husky), which will automatically run the command in `.husky/pre-commit` before commiting.
+
+This prevents commits that fail typecheck or the linter being committed (you can always add a type or linter ignore though).

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "analyze": "cross-env NODE_ENV='production' cross-env ANALYZE=true webpack",
     "deploy": "cross-env NODE_DEBUG=gh-pages gh-pages -d dist",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint src/parking/*.ts src/utils/*.ts src/utils/types/*.ts",
-    "lint:fix": "eslint src/parking/*.ts src/utils/*.ts src/utils/types/*.ts --fix",
+    "lint": "eslint src/**/*.ts",
+    "lint:fix": "eslint src/**/*.ts --fix",
     "prepare": "husky install"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "analyze": "cross-env NODE_ENV='production' cross-env ANALYZE=true webpack",
     "deploy": "cross-env NODE_DEBUG=gh-pages gh-pages -d dist",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint src/**/*.ts",
-    "lint:fix": "eslint src/**/*.ts --fix",
+    "lint": "eslint src/**/*.ts src/*.ts",
+    "lint:fix": "eslint src/**/*.ts src/*.ts --fix",
     "prepare": "husky install"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "deploy": "cross-env NODE_DEBUG=gh-pages gh-pages -d dist",
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/parking/*.ts src/utils/*.ts src/utils/types/*.ts",
-    "lint:fix": "eslint src/parking/*.ts src/utils/*.ts src/utils/types/*.ts --fix"
+    "lint:fix": "eslint src/parking/*.ts src/utils/*.ts src/utils/types/*.ts --fix",
+    "prepare": "husky install"
   },
   "keywords": [],
   "author": "Zlant",
@@ -41,6 +42,7 @@
     "eslint-plugin-promise": "^5.1.0",
     "gh-pages": "^3.1.0",
     "html-webpack-plugin": "^5.3.1",
+    "husky": "^7.0.4",
     "mini-css-extract-plugin": "^1.6.0",
     "postcss-loader": "^5.2.0",
     "postcss-preset-env": "^6.7.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "build": "cross-env NODE_ENV='production' webpack",
     "analyze": "cross-env NODE_ENV='production' cross-env ANALYZE=true webpack",
     "deploy": "cross-env NODE_DEBUG=gh-pages gh-pages -d dist",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src/parking/*.ts src/utils/*.ts src/utils/types/*.ts",
+    "lint:fix": "eslint src/parking/*.ts src/utils/*.ts src/utils/types/*.ts --fix"
   },
   "keywords": [],
   "author": "Zlant",

--- a/src/parking/data-url.ts
+++ b/src/parking/data-url.ts
@@ -18,6 +18,7 @@ export function getUrl(bounds: L.LatLngBounds, editorMode: boolean, useDevServer
     }
 }
 
+// eslint-disable-next-line
 function getOverpassEditorQuery(bounds: L.LatLngBounds) {
     return `
         [out:json];

--- a/src/parking/interface.ts
+++ b/src/parking/interface.ts
@@ -115,7 +115,7 @@ export function initMap(): L.Map {
     map.on('click', closeLaneInfo)
     map.on('click', areaInfoControl.closeAreaInfo)
 
-    layersControl.addTo(map);
+    layersControl.addTo(map)
 
     // @ts-expect-error
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "strictNullChecks": true,
     "skipLibCheck": true
   },
-  "include": ["src/parking/*.ts", "src/utils/*.ts", "src/utils/types/*.ts"]
+  "include": ["src/index.ts", "src/parking/*.ts", "src/utils/*.ts", "src/utils/types/*.ts"]
 }


### PR DESCRIPTION
Shortcut for command to run and fix (what can be automatically fixed) linter errors.

I also added a `pre-commit` hook using Husky so this automatically runs before you commit, so it's impossible to commit a change which breaks the typechecker or linter. See README.

The new dev dep in `package.json` will modify the `package-lock.json` but I don't know your version of Node - so when I run `npm i` my `package-lock.json` is completely changed.

For now this could be fixed by you running `npm i` and committing the `package-lock.json`, but a long term solution is https://github.com/zlant/parking-lanes/issues/94 (which I'm happy to implement).