### PR TITLE
iD Editor Link: Use standalone editor

### DIFF
--- a/src/parking/controls/area-info.ts
+++ b/src/parking/controls/area-info.ts
@@ -1,6 +1,6 @@
 import L from 'leaflet'
 import { hyper } from 'hyperhtml/esm'
-import { idUrl } from '../../utils/links'
+import { idEditorUrl } from '../../utils/links'
 import { OsmNode, OsmRelation, OsmWay } from '../../utils/types/osm-data'
 
 export default L.Control.extend({
@@ -39,7 +39,7 @@ function getPanel(osm: OsmNode | OsmWay | OsmRelation, body: any) {
                 <a href="https://openstreetmap.org/${osm.type}/${osm.id}" target="_blank">View in OSM</a>
                 <span style="float:right">
                     Edit:
-                    <a href="${idUrl + '&way=' + osm.id}"
+                    <a href="${idEditorUrl({ osmObjectType: 'way', osmObjectId: osm.id })}"
                        target="_blank">iD</a>
                 </span>
             </div>

--- a/src/parking/controls/lane-info.ts
+++ b/src/parking/controls/lane-info.ts
@@ -1,7 +1,7 @@
 import L, { LatLngLiteral } from 'leaflet'
 import { hyper } from 'hyperhtml/esm'
 import { handleJosmLinkClick } from '../..//utils/josm'
-import { idUrl, josmUrl, mapillaryUrl, overpassDeUrl } from '../../utils/links'
+import { idEditorUrl, josmUrl, mapillaryUrl, overpassDeUrl } from '../../utils/links'
 import { getLaneEditForm, setOsmChangeListener } from './editor/editor-form'
 import { OsmTags, OsmWay } from '../../utils/types/osm-data'
 
@@ -60,7 +60,7 @@ function getPanel(osm: OsmWay, body: any, mapCenter: LatLngLiteral) {
                     <a href="${josmUrl + overpassDeUrl + getWayWithRelationsOverpassQuery(osm.id).replace(/\s+/g, ' ')}"
                        target="_blank"
                        onclick=${handleJosmLinkClick}>Josm</a>,${' '}
-                    <a href="${idUrl + '&way=' + osm.id}"
+                    <a href="${idEditorUrl({ osmObjectType: 'way', osmObjectId: osm.id })}"
                        target="_blank">iD</a>
                 </span>
             </div>

--- a/src/parking/interface.ts
+++ b/src/parking/interface.ts
@@ -27,7 +27,7 @@ import {
 } from './parking-lane'
 
 import { getLocationFromCookie, setLocationToCookie } from '../utils/location-cookie'
-import { idUrl, josmUrl, overpassDeUrl } from '../utils/links'
+import { idEditorUrl, josmUrl, overpassDeUrl } from '../utils/links'
 import { downloadBbox, osmData, resetLastBounds } from '../utils/data-client'
 import { getUrl } from './data-url'
 import { addChangedEntity, changesStore } from '../utils/changes-store'
@@ -292,13 +292,14 @@ function addNewPoint(newPoints: ParkingPoint, map: L.Map): void {
 // Map move handler
 
 function handleMapMoveEnd() {
-    const { map } = (window as OurWindow);
-    (document.getElementById('ghc-josm') as HTMLLinkElement).href = josmUrl + overpassDeUrl + getHighwaysOverpassQuery();
-    (document.getElementById('ghc-id') as HTMLLinkElement).href = idUrl + '#map=' +
-    document.location.href.substring(document.location.href.indexOf('#') + 1)
-
+    const { map } = (window as OurWindow)
     const zoom = map.getZoom()
-    setLocationToCookie(map.getCenter(), zoom)
+    const center = map.getCenter();
+
+    (document.getElementById('ghc-josm') as HTMLLinkElement).href = josmUrl + overpassDeUrl + getHighwaysOverpassQuery();
+    (document.getElementById('ghc-id') as HTMLLinkElement).href = idEditorUrl({ zoom, center })
+
+    setLocationToCookie(center, zoom)
 
     updateLaneStylesByZoom(lanes, zoom)
     updatePointStylesByZoom(points, zoom);

--- a/src/utils/links.ts
+++ b/src/utils/links.ts
@@ -1,13 +1,33 @@
-import { LatLngLiteral } from 'leaflet'
+import { LatLng, LatLngLiteral } from 'leaflet'
+import { OsmNode, OsmRelation, OsmWay } from './types/osm-data'
 
 export const overpassDeUrl = 'https://overpass-api.de/api/interpreter?data='
 export const overpassVkUrl = 'https://maps.mail.ru/osm/tools/overpass/api/interpreter?data='
 export const josmUrl = 'http://127.0.0.1:8111/import?url='
-export const idUrl = 'https://www.openstreetmap.org/edit?editor=id'
 
 export const osmProdUrl = 'https://www.openstreetmap.org'
 export const osmDevUrl = 'https://master.apis.dev.openstreetmap.org'
 
 export function mapillaryUrl(center: LatLngLiteral) {
     return `https://www.mapillary.com/app/?lat=${center.lat}&lng=${center.lng}&z=17&focus=map&trafficSign=all`
+}
+
+interface idEditorUrlProps {
+    center?: LatLngLiteral | LatLng
+    zoom?: number
+    background?: string
+    osmObjectType?: OsmRelation['type'] | OsmWay['type'] | OsmNode['type']
+    osmObjectId?: number | string
+}
+export function idEditorUrl({ center, zoom, background, osmObjectType, osmObjectId }: idEditorUrlProps) {
+    const params: { [key: string]: string } = {
+        disable_features: 'boundaries',
+        photo_overlay: 'streetside,mapillary,kartaview',
+    }
+    if (zoom && center) params.map = `${zoom}/${center.lat}/${center.lng}`
+    if (background) params.background = background
+    if (osmObjectType && osmObjectId) params.id = `${osmObjectType.charAt(0)}${osmObjectId}`
+    const hashUrlParams = new URLSearchParams(params as any)
+
+    return `https://ideditor-release.netlify.app/#${hashUrlParams.toString()}`
 }


### PR DESCRIPTION
This refactors the iD Editor Link to use the stand alone editor to set more config options via URL params.

The editor function allows to generate an URL based on the map zoom+center or based on a osm object.

---

My initial goal was to extend this to support custom background layer (so the user sees the same background layer in iD that was selected in this editor before), but this addition requires more changes to the way the background layers are structured; maybe as part of a "allow local layer" refactoring.