### PR TITLE
Improve placeholder text for surface-input

### DIFF
--- a/src/parking/controls/editor/editor-form.ts
+++ b/src/parking/controls/editor/editor-form.ts
@@ -167,7 +167,7 @@ function getTagInput(osm: OsmWay, side: string, parkingType: string, tagTemplate
         }
         case 'parking:lane:{side}:surface': {
             input = getTextInput(tag, value)
-            input.placeholder = osm.tags.surface ?? input.placeholder
+            input.placeholder = `eg. ${osm.tags.surface ?? input.placeholder}`
             const laneTag = 'parking:lane:{side}'
                 .replace('{side}', side)
             hide = !['parallel', 'diagonal', 'perpendicular', 'marked', 'yes']


### PR DESCRIPTION
The placeholder for the surface input is now "eg. asphalt" to clarify, that it is just a suggestion that needs to be typed. It was easy to be seen as a value before.