### PR TITLE
Hide capacity input unless already specified

### DIFF
--- a/src/parking/controls/editor/editor-form.ts
+++ b/src/parking/controls/editor/editor-form.ts
@@ -165,6 +165,14 @@ function getTagInput(osm: OsmWay, side: string, parkingType: string, tagTemplate
             hide = osm.tags[conditionTag] !== 'disc'
             break
         }
+        case 'parking:lane:{side}:capacity': {
+            input = getTextInput(tag, value)
+            input.placeholder = 'eg. 10'
+            const capacityTags = 'parking:lane:{side}:capacity'
+                .replace('{side}', side)
+            hide = !!capacityTags
+            break
+        }
         case 'parking:lane:{side}:surface': {
             input = getTextInput(tag, value)
             input.placeholder = osm.tags.surface ?? input.placeholder


### PR DESCRIPTION
We consider it bad practice to map the capacity as number on a way since each split would multiply the capacity unless the mapper is not careful. Instead, we use data processing steps to calculate the capacity in Berlin.

Therefore, this change hides the capacity field unless a values is already present. This way existing data can be edited.

It also uses a clearer placeholder text.

---

Is this something for the main app as well?