### PR TITLE
Move the legend panel to the bottomleft

### DIFF
--- a/src/parking/interface.ts
+++ b/src/parking/interface.ts
@@ -97,7 +97,7 @@ export function initMap(): L.Map {
 
     new GithubControl({ position: 'bottomright' }).addTo(map)
         .setEditorModeCheckboxListener(handleEditorModeCheckboxChange)
-    new LegendControl({ position: 'bottomright' }).addTo(map)
+    new LegendControl({ position: 'bottomleft' }).addTo(map)
     new DatetimeControl({ position: 'topright' }).addTo(map)
         .setDatetime(datetime)
         .setDatetimeChangeListener(handleDatetimeChange)


### PR DESCRIPTION
This way there is less conflict with the image layer selection.

This is live at https://tordans.github.io/parking-lanes/#18/52.47846/13.43201.

Since we have a few more background layers in the Berlin-Edition, this change helps a lot.

---

Is this something for the main app as well?