### PR TITLE
Change table layout for conditional form

### DIFF
--- a/src/parking/controls/editor/editor-form.ts
+++ b/src/parking/controls/editor/editor-form.ts
@@ -287,10 +287,12 @@ function getConditionalInput(osm: OsmWay, tag: string, label: string, hide: bool
     return hyper`
         <tr id="${tag}" 
             class="conditional-tag"
-            style=${{ display: hide && !osm.tags[tag] ? 'none' : null }}>
-            <td colspan="2">
+            style=${{ display: hide ? 'none' : null }}>
+            <td style="vertical-align: top;">
+                <label title="${tag}">${label}</label>
+            </td>
+            <td>
                 <table>
-                    <tr><td><label title="${tag}">${label}</label></td></tr>
                     ${parsedConditionalTag.map((conditionalValue, i) => getConditionalPartInput(osm, tag, conditionalValue, i, values))}
                 </table>
             </td>


### PR DESCRIPTION

This way the label stays on the left (top) and the forms in the second column.
