### PR TITLE
Update mapnik URL to tiles.openstreetmap

### DIFF
--- a/src/parking/interface.ts
+++ b/src/parking/interface.ts
@@ -51,7 +51,7 @@ const fetchControl = new FetchControl({ position: 'topright' })
 
 // Reminder: Check `maxMaxZoomFromTileLayers` in `generateStyleMapByZoom()`
 const tileLayers = {
-    mapnik: L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    mapnik: L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
         maxZoom: 21,
         maxNativeZoom: 19,


### PR DESCRIPTION
Following the request of https://github.com/openstreetmap/operations/issues/737 the URL for osm tiles should not use the `{s}` prefix anymore.