### PR TITLE
Remove maxar from list of background layers

### DIFF
--- a/src/parking/interface.ts
+++ b/src/parking/interface.ts
@@ -62,18 +62,12 @@ const tileLayers = {
         maxZoom: 21,
         maxNativeZoom: 19,
     }),
-    maxar: L.tileLayer('https://services.digitalglobe.com/earthservice/tmsaccess/tms/1.0.0/DigitalGlobe:ImageryTileService@EPSG:3857@jpg/{z}/{x}/{-y}.jpg?connectId=c2cbd3f2-003a-46ec-9e46-26a3996d6484', {
-        attribution: "<a href='https://wiki.openstreetmap.org/wiki/DigitalGlobe'>Terms & Feedback</a>",
-        maxZoom: 21,
-        maxNativeZoom: 20,
-    }),
 }
 
 const layersControl = L.control.layers(
     {
         Mapnik: tileLayers.mapnik,
         'Esri Clarity': tileLayers.esri,
-        'Maxar Premium Imagery': tileLayers.maxar,
     },
     undefined,
     { position: 'bottomright' })


### PR DESCRIPTION
Maxar aerial imagery has been dead for a while now, see https://github.com/openstreetmap/iD/issues/9710 for more.