### PR TITLE
Add bing aerial imagery

### DIFF
--- a/src/parking/bing-imagery.ts
+++ b/src/parking/bing-imagery.ts
@@ -1,0 +1,66 @@
+import L from 'leaflet'
+
+function toQuadKey(x: number, y: number, z: any) {
+    let index = ''
+    for (let i = z; i > 0; i--) {
+        let b = 0
+        const mask = 1 << (i - 1)
+        if ((x & mask) !== 0) b++
+        if ((y & mask) !== 0) b += 2
+        index += b.toString()
+    }
+    return index
+}
+
+export async function addBingImagery(layersControl) {
+    // Key by @tordans from https://www.bingmapsportal.com/Application
+    const key = 'ArLnyyo1sSjfKJUAV3MPMPEkHkY3eCwzKf5MfEfiTHa67h5QFLoF8Im4GxNJ4a5K'
+    const url = `https://dev.virtualearth.net/REST/v1/Imagery/Metadata/AerialOSM?include=ImageryProviders&uriScheme=https&key=${key}`
+
+    // Get the image tiles template:
+    const metadata = await (await fetch(url)).json()
+    // FYI:
+    // "imageHeight": 256, "imageWidth": 256,
+    // "imageUrlSubdomains": ["t0","t1","t2","t3"],
+    // "zoomMax": 21,
+    const imageryResource = metadata.resourceSets[0].resources[0]
+    const template = new URL(imageryResource.imageUrl)
+    // Add tile image strictness param (n=)
+    // • n=f -> (Fail) returns a 404
+    // • n=z -> (Empty) returns a 200 with 0 bytes (no content)
+    // • n=t -> (Transparent) returns a 200 with a transparent (png) tile
+    if (!template.searchParams.has('n'))
+        template.searchParams.append('n', 'f')
+
+    // FYI: `template` looks like this but partly encoded
+    // https://ecn.{subdomain}.tiles.virtualearth.net/tiles/a{quadkey}.jpeg?g=14107&pr=odbl&n=z
+
+    layersControl.addBaseLayer(new BingImagery(template.toString()), 'Bing Aerial Imagery')
+}
+
+export class BingImagery extends L.TileLayer {
+    private readonly url: string
+
+    constructor(template: string) {
+        super('')
+        this.options.maxNativeZoom = 20 // The `metadata` say its 21, but that fails…
+        this.options.maxZoom = 22
+        this.url = template
+    }
+
+    public createTile(coords: any) {
+        const tile = document.createElement('img')
+        tile.src = this.getTileUrl(coords)
+        tile.alt = ''
+        return tile
+    }
+
+    public getTileUrl(coords: any) {
+        // Arg, the `new URL(template).toString()` mangles our template keys
+        const unescapeUrl = decodeURIComponent(this.url)
+        return L.Util.template(unescapeUrl, {
+            quadkey: toQuadKey(coords.x, coords.y, coords.z),
+            subdomain: 't1', // See `imageUrlSubdomains` above
+        })
+    }
+}

--- a/src/parking/interface.ts
+++ b/src/parking/interface.ts
@@ -1,43 +1,43 @@
 import L from 'leaflet'
 import 'leaflet/dist/leaflet.css'
 
-import 'leaflet.locatecontrol'
-import 'leaflet-polylineoffset'
 import 'leaflet-hash'
+import 'leaflet-polylineoffset'
 import 'leaflet-touch-helper'
+import 'leaflet.locatecontrol'
 
-import 'leaflet.locatecontrol/dist/L.Control.Locate.min.css'
 import 'font-awesome/css/font-awesome.min.css'
+import 'leaflet.locatecontrol/dist/L.Control.Locate.min.css'
 
 import { hyper } from 'hyperhtml/esm'
 
-import DatetimeControl from './controls/Datetime'
 import AppInfoControl from './controls/AppInfo'
-import LegendControl from './controls/Legend'
-import LaneInfoControl from './controls/LaneInfo'
 import AreaInfoControl from './controls/AreaInfo'
+import DatetimeControl from './controls/Datetime'
 import FetchControl from './controls/Fetch'
+import LaneInfoControl from './controls/LaneInfo'
+import LegendControl from './controls/Legend'
 
 import {
-    parseParkingLane,
+    getBacklights,
     parseChangedParkingLane,
+    parseParkingLane,
     updateLaneColorsByDate,
     updateLaneStylesByZoom,
-    getBacklights,
 } from './parking-lane'
 
-import { getLocationFromCookie, setLocationToCookie } from '../utils/location-cookie'
-import { downloadBbox, osmData, resetLastBounds } from '../utils/data-client'
-import { getUrl } from './data-url'
 import { addChangedEntity, changesStore } from '../utils/changes-store'
-import { authenticate, logout, userInfo, uploadChanges } from '../utils/osm-client'
+import { downloadBbox, osmData, resetLastBounds } from '../utils/data-client'
+import { getLocationFromCookie, setLocationToCookie } from '../utils/location-cookie'
+import { authenticate, logout, uploadChanges, userInfo } from '../utils/osm-client'
 import { type OurWindow } from '../utils/types/interfaces'
 import { type OsmWay } from '../utils/types/osm-data'
 import { type ParsedOsmData } from '../utils/types/osm-data-storage'
-import { type ParkingAreas, type ParkingPoint, type ParkingLanes } from '../utils/types/parking'
+import { type ParkingAreas, type ParkingLanes, type ParkingPoint } from '../utils/types/parking'
+import { getUrl } from './data-url'
 import { parseParkingArea, parseParkingRelation, updateAreaColorsByDate } from './parking-area'
 import { parseParkingPoint, updatePointColorsByDate, updatePointStylesByZoom } from './parking-point'
-import { type AppStateStore, useAppStateStore, AuthState } from './state'
+import { AuthState, useAppStateStore, type AppStateStore } from './state'
 
 const editorName = 'PLanes'
 const version = '0.8.8'

--- a/src/parking/interface.ts
+++ b/src/parking/interface.ts
@@ -34,6 +34,7 @@ import { type OurWindow } from '../utils/types/interfaces'
 import { type OsmWay } from '../utils/types/osm-data'
 import { type ParsedOsmData } from '../utils/types/osm-data-storage'
 import { type ParkingAreas, type ParkingLanes, type ParkingPoint } from '../utils/types/parking'
+import { addBingImagery } from './bing-imagery'
 import { getUrl } from './data-url'
 import { parseParkingArea, parseParkingRelation, updateAreaColorsByDate } from './parking-area'
 import { parseParkingPoint, updatePointColorsByDate, updatePointStylesByZoom } from './parking-point'
@@ -50,7 +51,7 @@ const areaInfoControl = new AreaInfoControl({ position: 'topright' })
 const fetchControl = new FetchControl({ position: 'topright' })
 
 // Reminder: Check `maxMaxZoomFromTileLayers` in `generateStyleMapByZoom()`
-const tileLayers = {
+const tileLayers: Record<string, L.TileLayer> = {
     mapnik: L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
         attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors',
         maxZoom: 21,
@@ -72,7 +73,9 @@ const layersControl = L.control.layers(
     undefined,
     { position: 'bottomright' })
 
-export function initMap(): L.Map {
+void addBingImagery(layersControl)
+
+export function initMap() {
     const root = document.querySelector('#map') as HTMLElement
     const map = L.map(root, { fadeAnimation: false })
 


### PR DESCRIPTION
Thanks to a code snippets by @mbrzakovic I managed to get the bing aerial imagery working. This PR add them asynchronously after fetching the right tiles URL template by using an api key that I created.

If the API handshake fails the entry in the imagery flyout is not added and there is a console error like a `401` for the `https://dev.virtualearth.net/REST/v1/Imagery/Metadata/AerialOSM` fetch.

### Preview

I deployed this version at https://tordans.github.io/parking-lanes/#17/52.47979/13.41402

<img width="181" alt="image" src="https://github.com/zlant/parking-lanes/assets/111561/702b2545-8ce3-4f1b-9ad7-b78a04ed843a">

### About the api key

Milos' explained to follow the process at https://learn.microsoft.com/en-us/bingmaps/getting-started/bing-maps-dev-center-help/getting-a-bing-maps-key. At https://www.bingmapsportal.com/Application I now have a key which I scoped to those domains:

<img width="553" alt="image" src="https://github.com/zlant/parking-lanes/assets/111561/128bb1bc-0858-4eab-a066-96de10bdc63c">

